### PR TITLE
Drive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Not yet on npm so you'll have to do it the good'ol fasioned way with a cheeky gi
 * `node index.js weather --city="manchester" --country="uk" --api-key="ABCD"` - Command to turn your BB8 Unit into your very own weather reporter, uses OpenWeather so be sure to get your own API key
 * `node index.js tweet --hash-tag="bb8" --delay=5000` - Command to search twitter and run the first hashtag it finds as a command. Eg a tweet "#disco #bb8" would run the `disco` command --consumer-key xxx --consumer-secret xxx --access-token-key xxx --access-token-secret xxx
 * `node index.js power` - A command to get details of the battery state.
+* `node index.js drive` - A command to enable you to take input from the keyboard and 'drive' your BB-8 with the arrow keys.
 * `node index.js express --port=4000` - Command to run an express server which has a single POST endpoint which you can send a JSON object to. See below for more details.
 
 ### Express Server

--- a/commands/drive.js
+++ b/commands/drive.js
@@ -1,0 +1,39 @@
+module.exports = function (bb8) {
+
+  //variation of the roll command to enable input from keyboard
+  //useful when it you get commands from the Internet or just to play with
+  //BB-8 using nodejs
+  console.log('Drive mode enabled');
+  console.log('Press ctrl+c to exit');
+
+  var stdin = process.stdin;
+  stdin.setRawMode(true);
+  stdin.resume();
+  stdin.setEncoding('utf8');
+
+  stdin.on('data', function(key){
+    bb8.color('#000000');
+    if (key == '\u001B\u005B\u0041') {
+      //console.log('up');
+      bb8.stop();
+      bb8.roll(150, 0);
+    }
+    if (key == '\u001B\u005B\u0043') {
+      //console.log('right');
+      bb8.stop();
+      bb8.roll(150, 90);
+    }
+    if (key == '\u001B\u005B\u0042') {
+      //console.log('down');
+      bb8.stop();
+      bb8.roll(150, 180);
+    }
+    if (key == '\u001B\u005B\u0044') {
+      //console.log('left');
+      bb8.stop();
+      bb8.roll(150, 270);
+    }
+    if (key == '\u0003') { process.exit(); }
+  });
+
+};

--- a/commands/drive.js
+++ b/commands/drive.js
@@ -1,39 +1,67 @@
+var keypress = require('keypress');
+
 module.exports = function (bb8) {
 
   //variation of the roll command to enable input from keyboard
   //useful when it you get commands from the Internet or just to play with
   //BB-8 using nodejs
-  console.log('Drive mode enabled');
+
+  console.log('Drive mode enabled\n Press e to calibrate and tap e again to point the BB8 in the direction you want to drive and q to finish calibration\n Use w,s,a,d style control the BB8 \n Use spacebar to stop the BB8');
   console.log('Press ctrl+c to exit');
 
   var stdin = process.stdin;
-  stdin.setRawMode(true);
-  stdin.resume();
   stdin.setEncoding('utf8');
+  keypress(stdin);
 
-  stdin.on('data', function(key){
+  console.log("starting to listen for arrow key presses");
+
+  stdin.on("keypress", function(ch,key) {
+    //console.log('got "keypress"', key);
     bb8.color('#000000');
-    if (key == '\u001B\u005B\u0041') {
+
+    if(key && key.name === 'e') {
+      bb8.startCalibration();
+      bb8.roll(1, 90, 2, function() {
+        setTimeout(function() {
+          bb8.setHeading(0, function() {
+            bb8.roll(0,0,1);
+          });
+        }, 300);
+      });
+    }
+    if(key && key.name === 'q') {
+      bb8.finishCalibration();
+    }
+    if(key && key.name === 'w'){
       //console.log('up');
       bb8.stop();
       bb8.roll(150, 0);
     }
-    if (key == '\u001B\u005B\u0043') {
+    if(key && key.name === 'd'){
       //console.log('right');
       bb8.stop();
       bb8.roll(150, 90);
     }
-    if (key == '\u001B\u005B\u0042') {
+    if(key && key.name === 's'){
       //console.log('down');
       bb8.stop();
       bb8.roll(150, 180);
     }
-    if (key == '\u001B\u005B\u0044') {
+    if(key && key.name === 'a'){
       //console.log('left');
       bb8.stop();
       bb8.roll(150, 270);
     }
-    if (key == '\u0003') { process.exit(); }
+    if(key && key.name === 'space'){
+      //console.log('space');
+      bb8.stop();
+    }
+    if (key && key.ctrl && key.name === 'c') {
+      process.stdin.pause();
+      process.exit();
+    }
   });
 
+  stdin.setRawMode(true);
+  stdin.resume();
 };

--- a/index.js
+++ b/index.js
@@ -86,6 +86,13 @@ program
     executeCommand('power');
   });
 
+program
+  .command('drive')
+  .description('Command to accept keyboard input--use arrow keys')
+  .action(function (options) {
+    executeCommand('drive');
+  });
+
 try {
     program.parse(process.argv);
 } catch (e) {

--- a/libs/bb8-instance.js
+++ b/libs/bb8-instance.js
@@ -2,12 +2,12 @@ var sphero = require("sphero"),
     config = require('home-config').load('.bb8config');
 
 module.exports = function() {
-  
+
   if(typeof(config.BB8_UUID) !== 'undefined') {
     return sphero(config.BB8_UUID);
   }
 
   return false;
-}
+};
 
 module.exports.config = config;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "play-sound": "0.0.7",
     "request": "^2.67.0",
     "sphero": "^0.7.0",
-    "twitter": "^1.2.5"
+    "twitter": "^1.2.5",
+    "keypress": "0.2.1"
   },
   "devDependencies": {
     "nodemon": "^1.8.1"


### PR DESCRIPTION
Enable input from keyboard to 'drive' the BB-8 in the desired direction.
Takes input in wsad style.
Has callibration now.

See console log messages for more inputs.

Add the use of keypress module to control the keyboard inputs.
Add a semicolon in libs/bb8-instance.js.
